### PR TITLE
Fixed warnings being interpreted as errors

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "prod": "serve -s build",
     "test": "react-scripts test --transformIgnorePatterns 'node_modules/(?!axios)/'",
     "test:e2e": "start-server-and-test 'node e2e/test-environment-setup.js' http://localhost:8000/health prod 3000 \"cd e2e && jest\"",


### PR DESCRIPTION
Just a tiny bug that was preventing e2e tests to run, since when the application builds it throws an error whenever a warning is found.